### PR TITLE
Return the encoded value rather than "1" when not using sprintf

### DIFF
--- a/lib/String/Flogger.pm
+++ b/lib/String/Flogger.pm
@@ -98,7 +98,7 @@ sub flog {
     return $class->format_string($fmt, $class->_encrefs(\@data));
   }
 
-  return $class->_encrefs([ $input ]);
+  return ( $class->_encrefs([ $input ]) )[0];
 }
 
 sub format_string {

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,7 +1,7 @@
 #!perl
 use strict;
 use warnings;
-use Test::More tests => 4;
+use Test::More tests => 6;
 use String::Flogger qw(flog);
 
 is(
@@ -28,3 +28,14 @@ is(
   "%s <- \\\\1",
 );
 
+like(
+  flog({foo => 'bar'}),
+  qr/foo.+bar/,
+  "hashref keys/values printed",
+);
+
+like(
+  flog(sub { +{foo => 'bar'} }),
+  qr/foo.+bar/,
+  "hashref keys/values printed",
+);


### PR DESCRIPTION
Passing something like a hashref to `flog` returns `1` instead of the encoded value (in scalar context).

This usage is undocumented, but the result seemed unintentional.

Just thought I'd pass the idea along.
